### PR TITLE
udev rule for new nanoDMX usb dongle

### DIFF
--- a/udev_rules/98-led.rules
+++ b/udev_rules/98-led.rules
@@ -1,1 +1,2 @@
 KERNEL=="ttyUSB?", ATTRS{interface}=="USB-DMX-Interface", SYMLINK+="ttyLED", MODE="0666", GROUP="dialout"
+SUBSYSTEM=="usb*", ACTION=="add|change", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2018", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"


### PR DESCRIPTION
The new nanoDMX usb dongle is recognized as an ttyACM device. Ubuntus Modemmanager is automatically claiming these kind of USB resources. Thats why we need this udev roule, it prevents the modemmanager to access and block this device.