### PR TITLE
Fix upstart install scripts

### DIFF
--- a/InstallCob4.sh
+++ b/InstallCob4.sh
@@ -19,7 +19,7 @@ function BasicInstallation {
   echo -e "\n${green}INFO:Installing basic tools${NC}\n"
   sleep 5
   sudo apt-get update
-  sudo apt-get install vim tree gitg git-gui meld curl openjdk-6-jdk zsh terminator language-pack-de language-pack-en ipython -y --force-yes
+  sudo apt-get install vim tree gitg git-gui meld curl default-jdk terminator language-pack-de language-pack-en ipython nmap -y --force-yes
 
   echo -e "\n${green}INFO:Update grub to avoid hangs on reboot${NC}\n"
   sleep 5
@@ -66,7 +66,7 @@ function BasicInstallation {
   wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   echo -e "\n${green}   INFO: Install ROS${NC}\n"
   sudo apt-get update
-  sudo apt-get install ros-indigo-rosbash python-ros-* ros-indigo-care-o-bot-robot -y --force-yes
+  sudo apt-get install ros-indigo-rosbash ros-indigo-care-o-bot-robot -y --force-yes
   sudo rosdep init
   rosdep update
 

--- a/InstallCob4.sh
+++ b/InstallCob4.sh
@@ -66,7 +66,7 @@ function BasicInstallation {
   wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   echo -e "\n${green}   INFO: Install ROS${NC}\n"
   sudo apt-get update
-  sudo apt-get install ros-indigo-rosbash ros-indigo-care-o-bot-robot -y --force-yes
+  sudo apt-get install ros-indigo-rosbash ros-indigo-care-o-bot-robot python-rosdep python-rosinstall -y --force-yes
   sudo rosdep init
   rosdep update
 

--- a/scripts/cob-shutdown
+++ b/scripts/cob-shutdown
@@ -7,7 +7,7 @@ fi
 
 # Script for executing commands on all cob-pc's.
 IP=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
-client_list=$(nmap --unprivileged $IP-100 --system-dns | grep report | awk '{print $5}')
+client_list=$(nmap --unprivileged $IP-98 --system-dns | grep report | awk '{print $5}')
 
 ##### uncomment the following lines if Windows runs as a Virtual Machine
 #cob-stop-vm-win

--- a/scripts/cob-shutdown
+++ b/scripts/cob-shutdown
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 
-# Script for executing commands on all cob-pc's.
-IP=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
-
-client_list=$(nmap $IP-100 --system-dns | grep report | awk '{print $5}')
-
 if [[ $HOSTNAME != *"b"* ]]; then 
 	echo "FATAL: CAN ONLY BE EXECUTED ON BASE PC, current host is $HOSTNAME"
 	exit
 fi
+
+# Script for executing commands on all cob-pc's.
+IP=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
+client_list=$(nmap --unprivileged $IP-100 --system-dns | grep report | awk '{print $5}')
 
 ##### uncomment the following lines if Windows runs as a Virtual Machine
 #cob-stop-vm-win
@@ -34,6 +33,10 @@ fi
 #done
 
 for client in $client_list; do
+    if [ $client == $HOSTNAME ] ; then
+        echo "skipping $client"
+        continue
+    fi
     echo "-------------------------------------------"
     echo "Executing <<"shutdown">> on $client"  
     echo "-------------------------------------------"
@@ -46,6 +49,10 @@ for client in $client_list; do
 done
 
 for client in $client_list; do
+    if [ $client == $HOSTNAME ] ; then
+        echo "skipping $client"
+        continue
+    fi
     echo "-------------------------------------------"
     echo "Executing <<waiting for>> on" $client  
     echo "-------------------------------------------"
@@ -53,7 +60,7 @@ for client in $client_list; do
     shutdown=false
     Crono=0
     while [[ !$shutdown &&  $Crono -le 60 ]]; do
-      ping -c 1 -w 3 $client
+      ping -qc 1 -w 3 $client > /dev/null
       if [ $? -ne 0 ] ; then
         shutdown=true
         echo $client down

--- a/upstart/upstart_install.sh
+++ b/upstart/upstart_install.sh
@@ -17,30 +17,6 @@ sudo sh -c 'echo "%users ALL=NOPASSWD:/usr/sbin/cob-stop"' | sudo sed -i -e "\|%
 
 sudo sh -c 'echo "%users ALL=NOPASSWD:/usr/sbin/cob-stop-core"' | sudo sed -i -e "\|%users ALL=NOPASSWD:/usr/sbin/cob-stop-core|h; \${x;s|%users ALL=NOPASSWD:/usr/sbin/cob-stop-core||;{g;t};a\\" -e "%users ALL=NOPASSWD:/usr/sbin/cob-stop-core" -e "}" /etc/sudoers
 
-	
-
-client_list="
-$robot_name-b1
-$robot_name-t1
-$robot_name-t2
-$robot_name-t3
-$robot_name-s1
-$robot_name-h1"
-
-for client in $client_list; do
-	echo "-------------------------------------------"
-	echo "Executing on $client"
-	echo "-------------------------------------------"
-	echo ""
-	ssh $client "sudo mkdir -p /etc/ros/$ROS_DISTRO/cob.d"
-	ssh $client "sudo ln -s /u/robot/git/setup_cob4/upstart/cob.d/setup /etc/ros/$ROS_DISTRO/cob.d/setup"
-	ret=${PIPESTATUS[0]}
-	if [ $ret != 0 ] ; then
-		echo "command return an error (error code: $ret), aborting..."
-	fi
-	echo ""
-done
-
 camera_client_list="
 $robot_name-t2
 $robot_name-t3
@@ -55,6 +31,8 @@ for client in $camera_client_list; do
         ssh $client "sudo update-rc.d check_cameras.sh defaults"
 done
 
+sudo mkdir -p /etc/ros/$ROS_DISTRO/cob.d
+sudo ln -s /u/robot/git/setup_cob4/upstart/cob.d/setup /etc/ros/$ROS_DISTRO/cob.d/setup
 sudo cp -rf /u/robot/git/setup_cob4/upstart/cob.d/launch /etc/ros/$ROS_DISTRO/cob.d/
 sudo sed -i "s/myrobot/$ROBOT/g" /etc/ros/$ROS_DISTRO/cob.d/launch/robot/robot.launch
 sudo sed -i "s/myrobot/$robot_name/g" /etc/ros/indigo/cob.d/setup/setup.sh

--- a/upstart/upstart_install.sh
+++ b/upstart/upstart_install.sh
@@ -3,12 +3,12 @@
 robot_name="${HOSTNAME//-b1}"
 
 sudo apt-get install ros-indigo-robot-upstart
-sudo cp /u/robot/git/setup_cob4/upstart/cob.conf /etc/init/cob.conf
-sudo cp /u/robot/git/setup_cob4/upstart/cob-start /usr/sbin/cob-start
+sudo cp -f /u/robot/git/setup_cob4/upstart/cob.conf /etc/init/cob.conf
+sudo cp -f /u/robot/git/setup_cob4/upstart/cob-start /usr/sbin/cob-start
 sudo sed -i "s/myrobot/$ROBOT/g" /usr/sbin/cob-start
 sudo sed -i "s/mydistro/$ROS_DISTRO/g" /usr/sbin/cob-start
-sudo cp /u/robot/git/setup_cob4/upstart/cob-stop /usr/sbin/cob-stop
-sudo cp /u/robot/git/setup_cob4/upstart/cob-stop-core /usr/sbin/cob-stop-core
+sudo cp -f /u/robot/git/setup_cob4/upstart/cob-stop /usr/sbin/cob-stop
+sudo cp -f /u/robot/git/setup_cob4/upstart/cob-stop-core /usr/sbin/cob-stop-core
 
 sudo sh -c 'echo "%users ALL=NOPASSWD:/usr/sbin/cob-start"' | sudo sed -i -e "\|%users ALL=NOPASSWD:/usr/sbin/cob-start|h; \${x;s|%users ALL=NOPASSWD:/usr/sbin/cob-start||;{g;t};a\\" -e "%users ALL=NOPASSWD:/usr/sbin/cob-start" -e "}" /etc/sudoers 
 
@@ -50,11 +50,11 @@ for client in $camera_client_list; do
         echo "Executing on $client"
         echo "-------------------------------------------"
         echo ""
-        ssh $client "sudo cp /u/robot/git/setup_cob4/upstart/check_cameras.sh /etc/init.d/check_cameras.sh"
+        ssh $client "sudo cp -f /u/robot/git/setup_cob4/upstart/check_cameras.sh /etc/init.d/check_cameras.sh"
         ssh $client "sudo update-rc.d check_cameras.sh defaults"
 done
 
-sudo cp -r /u/robot/git/setup_cob4/upstart/cob.d/launch /etc/ros/$ROS_DISTRO/cob.d/
+sudo cp -rf /u/robot/git/setup_cob4/upstart/cob.d/launch /etc/ros/$ROS_DISTRO/cob.d/
 sudo sed -i "s/myrobot/$ROBOT/g" /etc/ros/$ROS_DISTRO/cob.d/launch/robot/robot.launch
 sudo sed -i "s/myrobot/$robot_name/g" /etc/ros/indigo/cob.d/setup/setup.sh
 

--- a/upstart/upstart_install.sh
+++ b/upstart/upstart_install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 robot_name="${HOSTNAME//-b1}"
+ROS_DISTRO="indigo"
 
 sudo apt-get install ros-indigo-robot-upstart
 sudo cp -f /u/robot/git/setup_cob4/upstart/cob.conf /etc/init/cob.conf

--- a/upstart_msh/check_cameras.sh
+++ b/upstart_msh/check_cameras.sh
@@ -1,1 +1,0 @@
-../upstart/check_cameras.sh

--- a/upstart_msh/cob.d/launch/robot/robot.launch
+++ b/upstart_msh/cob.d/launch/robot/robot.launch
@@ -1,13 +1,8 @@
 <?xml version="1.0"?>
 <launch>
 	
-	<param name="/use_sim_time" value="false"/>
-	<arg name="robot" default="cob4-1"/>
-	<!--arg name="pkg_env_config" default="cob_default_env_config"/-->
-
 	<include file="$(find msh_bringup)/launch/all.launch" >
 		<arg name="env-script" value="/u/msh/git/care-o-bot/devel/env.sh"/>
-		<arg name="robot_env" value="saturn-ingolstadt" />
 	</include>
 
 </launch>

--- a/upstart_msh/upstart_install.sh
+++ b/upstart_msh/upstart_install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 robot_name="${HOSTNAME//-b1}"
 ROS_DISTRO="indigo"
 
@@ -40,16 +42,14 @@ for client in $client_list; do
 	echo "-------------------------------------------"
 	echo ""
 	ssh $client "sudo mkdir -p /etc/ros/$ROS_DISTRO/cob.d"
-	ssh $client "sudo ln -s /u/robot/git/setup_cob4/upstart_msh/cob.d/setup /etc/ros/$ROS_DISTRO/cob.d/setup"
-	ret=${PIPESTATUS[0]}
-	if [ $ret != 0 ] ; then
-		echo "command return an error (error code: $ret), aborting..."
-	fi
+	ssh $client "sudo cp -rf /u/robot/git/setup_cob4/upstart_msh/cob.d /etc/ros/$ROS_DISTRO/"
+	sudo sed -i "s/myrobot/$ROBOT/g" /etc/ros/$ROS_DISTRO/cob.d/launch/robot/robot.launch
 	echo ""
 done
 
+# define ASUS camera pcs
 camera_client_list="
-$robot_name-t2
+$robot_name-t1
 $robot_name-t3
 $robot_name-s1"
 
@@ -61,6 +61,3 @@ for client in $camera_client_list; do
         ssh $client "sudo cp -f /u/robot/git/setup_cob4/upstart/check_cameras.sh /etc/init.d/check_cameras.sh"
         ssh $client "sudo update-rc.d check_cameras.sh defaults"
 done
-
-sudo cp -rf /u/robot/git/setup_cob4/upstart_msh/cob.d /etc/ros/$ROS_DISTRO/.
-sudo sed -i "s/myrobot/$ROBOT/g" /etc/ros/$ROS_DISTRO/cob.d/launch/robot/robot.launch

--- a/upstart_msh/upstart_install.sh
+++ b/upstart_msh/upstart_install.sh
@@ -41,25 +41,6 @@ if ! sudo grep -q "$sudoers_string" /etc/sudoers ; then
   echo $sudoers_string | sudo tee -a /etc/sudoers
 fi
 
-client_list="
-$robot_name-b1
-$robot_name-t1
-$robot_name-t2
-$robot_name-t3
-$robot_name-s1
-$robot_name-h1"
-
-for client in $client_list; do
-	echo "-------------------------------------------"
-	echo "Executing on $client"
-	echo "-------------------------------------------"
-	echo ""
-	ssh $client "sudo mkdir -p /etc/ros/$ROS_DISTRO/cob.d"
-	ssh $client "sudo cp -rf /u/robot/git/setup_cob4/upstart_msh/cob.d /etc/ros/$ROS_DISTRO/"
-	sudo sed -i "s/myrobot/$ROBOT/g" /etc/ros/$ROS_DISTRO/cob.d/launch/robot/robot.launch
-	echo ""
-done
-
 # define ASUS camera pcs
 camera_client_list="
 $robot_name-t1
@@ -74,3 +55,7 @@ for client in $camera_client_list; do
         ssh $client "sudo cp -f /u/robot/git/setup_cob4/upstart/check_cameras.sh /etc/init.d/check_cameras.sh"
         ssh $client "sudo update-rc.d check_cameras.sh defaults"
 done
+
+sudo mkdir -p /etc/ros/$ROS_DISTRO/cob.d
+sudo cp -rf /u/robot/git/setup_cob4/upstart_msh/cob.d /etc/ros/$ROS_DISTRO/
+sudo sed -i "s/myrobot/$ROBOT/g" /etc/ros/$ROS_DISTRO/cob.d/launch/robot/robot.launch

--- a/upstart_msh/upstart_install.sh
+++ b/upstart_msh/upstart_install.sh
@@ -7,26 +7,39 @@ ROS_DISTRO="indigo"
 
 sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob.conf /etc/init/cob.conf
 sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob_msh.conf /etc/init/cob_msh.conf
+
 sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob-start /usr/sbin/cob-start
 sudo sed -i "s/myrobotname/$robot_name/g" /usr/sbin/cob-start
 sudo sed -i "s/mydistro/$ROS_DISTRO/g" /usr/sbin/cob-start
 sudo sed -i "s/myrobot/$ROBOT/g" /usr/sbin/cob-start
 sudo sed -i "s/myuser/msh/g" /usr/sbin/cob-start
-echo "%users ALL=NOPASSWD:/usr/sbin/cob-start" | sudo tee -a /etc/sudoers
+sudoers_string="%users ALL=NOPASSWD:/usr/sbin/cob-start"
+if ! sudo grep -q "$sudoers_string" /etc/sudoers ; then
+  echo $sudoers_string | sudo tee -a /etc/sudoers
+fi
 
 sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob-stop /usr/sbin/cob-stop
 sudo sed -i "s/myrobotname/$robot_name/g" /usr/sbin/cob-stop
 sudo sed -i "s/myuser/msh/g" /usr/sbin/cob-stop
 sudo sed -i "s/mydistro/$ROS_DISTRO/g" /usr/sbin/cob-stop
-echo "%users ALL=NOPASSWD:/usr/sbin/cob-stop" | sudo tee -a /etc/sudoers
+sudoers_string="%users ALL=NOPASSWD:/usr/sbin/cob-stop"
+if ! sudo grep -q "$sudoers_string" /etc/sudoers ; then
+  echo $sudoers_string | sudo tee -a /etc/sudoers
+fi
 
 sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob-start-gui /usr/sbin/cob-start-gui
 sudo sed -i "s/myrobotname/$robot_name/g" /usr/sbin/cob-start-gui
-echo "%users ALL=NOPASSWD:/usr/sbin/cob-start-gui" | sudo tee -a /etc/sudoers
+sudoers_string="%users ALL=NOPASSWD:/usr/sbin/cob-start-gui"
+if ! sudo grep -q "$sudoers_string" /etc/sudoers ; then
+  echo $sudoers_string | sudo tee -a /etc/sudoers
+fi
 
 sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob-stop-gui /usr/sbin/cob-stop-gui
 sudo sed -i "s/myrobotname/$robot_name/g" /usr/sbin/cob-stop-gui
-echo "%users ALL=NOPASSWD:/usr/sbin/cob-stop-gui" | sudo tee -a /etc/sudoers
+sudoers_string="%users ALL=NOPASSWD:/usr/sbin/cob-stop-gui"
+if ! sudo grep -q "$sudoers_string" /etc/sudoers ; then
+  echo $sudoers_string | sudo tee -a /etc/sudoers
+fi
 
 client_list="
 $robot_name-b1

--- a/upstart_msh/upstart_install.sh
+++ b/upstart_msh/upstart_install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 robot_name="${HOSTNAME//-b1}"
+ROS_DISTRO="indigo"
 
 sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob.conf /etc/init/cob.conf
 sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob_msh.conf /etc/init/cob_msh.conf
@@ -14,6 +15,7 @@ echo "%users ALL=NOPASSWD:/usr/sbin/cob-start" | sudo tee -a /etc/sudoers
 sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob-stop /usr/sbin/cob-stop
 sudo sed -i "s/myrobotname/$robot_name/g" /usr/sbin/cob-stop
 sudo sed -i "s/myuser/msh/g" /usr/sbin/cob-stop
+sudo sed -i "s/mydistro/$ROS_DISTRO/g" /usr/sbin/cob-stop
 echo "%users ALL=NOPASSWD:/usr/sbin/cob-stop" | sudo tee -a /etc/sudoers
 
 sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob-start-gui /usr/sbin/cob-start-gui

--- a/upstart_msh/upstart_install.sh
+++ b/upstart_msh/upstart_install.sh
@@ -2,25 +2,25 @@
 
 robot_name="${HOSTNAME//-b1}"
 
-sudo cp /u/robot/git/setup_cob4/upstart_msh/cob.conf /etc/init/cob.conf
-sudo cp /u/robot/git/setup_cob4/upstart_msh/cob_msh.conf /etc/init/cob_msh.conf
-sudo cp /u/robot/git/setup_cob4/upstart_msh/cob-start /usr/sbin/cob-start
+sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob.conf /etc/init/cob.conf
+sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob_msh.conf /etc/init/cob_msh.conf
+sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob-start /usr/sbin/cob-start
 sudo sed -i "s/myrobotname/$robot_name/g" /usr/sbin/cob-start
 sudo sed -i "s/mydistro/$ROS_DISTRO/g" /usr/sbin/cob-start
 sudo sed -i "s/myrobot/$ROBOT/g" /usr/sbin/cob-start
 sudo sed -i "s/myuser/msh/g" /usr/sbin/cob-start
 echo "%users ALL=NOPASSWD:/usr/sbin/cob-start" | sudo tee -a /etc/sudoers
 
-sudo cp /u/robot/git/setup_cob4/upstart_msh/cob-stop /usr/sbin/cob-stop
+sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob-stop /usr/sbin/cob-stop
 sudo sed -i "s/myrobotname/$robot_name/g" /usr/sbin/cob-stop
 sudo sed -i "s/myuser/msh/g" /usr/sbin/cob-stop
 echo "%users ALL=NOPASSWD:/usr/sbin/cob-stop" | sudo tee -a /etc/sudoers
 
-sudo cp /u/robot/git/setup_cob4/upstart_msh/cob-start-gui /usr/sbin/cob-start-gui
+sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob-start-gui /usr/sbin/cob-start-gui
 sudo sed -i "s/myrobotname/$robot_name/g" /usr/sbin/cob-start-gui
 echo "%users ALL=NOPASSWD:/usr/sbin/cob-start-gui" | sudo tee -a /etc/sudoers
 
-sudo cp /u/robot/git/setup_cob4/upstart_msh/cob-stop-gui /usr/sbin/cob-stop-gui
+sudo cp -f /u/robot/git/setup_cob4/upstart_msh/cob-stop-gui /usr/sbin/cob-stop-gui
 sudo sed -i "s/myrobotname/$robot_name/g" /usr/sbin/cob-stop-gui
 echo "%users ALL=NOPASSWD:/usr/sbin/cob-stop-gui" | sudo tee -a /etc/sudoers
 
@@ -56,9 +56,9 @@ for client in $camera_client_list; do
         echo "Executing on $client"
         echo "-------------------------------------------"
         echo ""
-        ssh $client "sudo cp /u/robot/git/setup_cob4/upstart_msh/check_cameras.sh /etc/init.d/check_cameras.sh"
+        ssh $client "sudo cp -f /u/robot/git/setup_cob4/upstart/check_cameras.sh /etc/init.d/check_cameras.sh"
         ssh $client "sudo update-rc.d check_cameras.sh defaults"
 done
 
-sudo cp -r /u/robot/git/setup_cob4/upstart_msh/cob.d /etc/ros/$ROS_DISTRO/.
+sudo cp -rf /u/robot/git/setup_cob4/upstart_msh/cob.d /etc/ros/$ROS_DISTRO/.
 sudo sed -i "s/myrobot/$ROBOT/g" /etc/ros/$ROS_DISTRO/cob.d/launch/robot/robot.launch


### PR DESCRIPTION
fix #79 
- both upstart version (only bringup and msh) use the same check_cameras script version (solves symlink error)
- use -f (force) to copy files, allowing the use of the install script also to update  the installed version