### PR TITLE
update rosinstall to clone the cob_navigation overlay

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -27,6 +27,10 @@
     local-name: cob_hand
     version: indigo_dev
 - git:
+    uri: 'https://github.com/ipa320/cob_navigation.git'
+    local-name: cob_navigation
+    version: indigo_dev
+- git:
     uri: 'https://github.com/ipa320/cob_robots.git'
     local-name: cob_robots
     version: indigo_dev


### PR DESCRIPTION
docker_control doesn't work with the release version of cob_linear_nav