### PR TITLE
use proper java version for headless build

### DIFF
--- a/cob-pcs/user.bashrc
+++ b/cob-pcs/user.bashrc
@@ -140,4 +140,3 @@ case '$ROS_PACKAGE_PATH' in
     ;;
 esac
 
-export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64

--- a/cob-pcs/user.bashrc
+++ b/cob-pcs/user.bashrc
@@ -140,4 +140,4 @@ case '$ROS_PACKAGE_PATH' in
     ;;
 esac
 
-export JAVA_HOME=/usr/lib/jvm/java-6-openjdk-amd64
+export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64


### PR DESCRIPTION
required for headless build for msh_voice_control

@ipa-fxm will take care that .bashrc of existing users are modified accordingly