### PR TITLE
HotFix : cob-shutdown

### DIFF
--- a/scripts/cob-shutdown
+++ b/scripts/cob-shutdown
@@ -49,7 +49,7 @@ for client in $client_list; do
 done
 
 for client in $client_list; do
-    if [ $client == $HOSTNAME ] ; then
+    if [ $client == $IP ] ; then
         echo "skipping $client"
         continue
     fi

--- a/scripts/cob-shutdown
+++ b/scripts/cob-shutdown
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 
 if [[ $HOSTNAME != *"b"* ]]; then 
-	echo "FATAL: CAN ONLY BE EXECUTED ON BASE PC, current host is $HOSTNAME"
-	exit
+    echo "FATAL: CAN ONLY BE EXECUTED ON BASE PC, current host is $HOSTNAME"
+    exit
 fi
 
-# Script for executing commands on all cob-pc's.
-IP=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
-client_list=$(nmap --unprivileged $IP-98 --system-dns | grep report | awk '{print $5}')
+# get pcs in local network
+IP=$(`hostname -I | awk '{print $1}'`)
+client_list=$(nmap --unprivileged $IP-98 --system-dns | grep report | awk '{print $6}' | sed 's/(//g;s/)//g')
 
 ##### uncomment the following lines if Windows runs as a Virtual Machine
 #cob-stop-vm-win
-
+#
 #rm -rf /tmp/runningVMS
 #Crono=0
 #while [[ $Crono -le 60 ]]; do
@@ -33,7 +33,7 @@ client_list=$(nmap --unprivileged $IP-98 --system-dns | grep report | awk '{prin
 #done
 
 for client in $client_list; do
-    if [ $client == $HOSTNAME ] ; then
+    if [ $client == $IP ] ; then
         echo "skipping $client"
         continue
     fi


### PR DESCRIPTION
don't use the hostname variable given by nmap, it can contain a subdomain (for example for cob4-7 was cob4-7-b1.cob4-7 ) , in this case the HOSTNAME was not equal to the client name and the base pc was switched off the first producing a hard shutdown for all the other pcs...

Please merge asap!! 