### PR TITLE
Fix: cob-command on cob4-7

### DIFF
--- a/scripts/cob-command
+++ b/scripts/cob-command
@@ -11,8 +11,7 @@ upstart_file_path="/etc/ros/cob.yaml"
 
 get_client_and_user_list(){
   IP=$(/sbin/ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
-  client_list=$(nmap --unprivileged $IP-98 --system-dns | grep report | awk '{print $6}' | sed 's/(//g;s/)//g') 
-
+  client_list=$(nmap --unprivileged $IP-98 --system-dns | grep report | awk '{print $6}' | sed 's/(//g;s/)//g' | tr '\n' ' ') 
   pos=0
   for i in $client_list
   do

--- a/scripts/cob-shutdown
+++ b/scripts/cob-shutdown
@@ -7,7 +7,7 @@ fi
 
 # get pcs in local network
 IP=$(hostname -I | awk '{print $1}')
-client_list=$(nmap --unprivileged $IP-98 --system-dns | grep report | awk '{print $6}' | sed 's/(//g;s/)//g')
+client_list=$(nmap --unprivileged $IP-98 --system-dns | grep report | awk '{print $6}' | sed 's/(//g;s/)//g' | tr '\n' ' ')
 
 ##### uncomment the following lines if Windows runs as a Virtual Machine
 #cob-stop-vm-win


### PR DESCRIPTION
cob-command was not working on cob4-7 because nmap was not returning a list, the same lines worked without problems for cob-shutdown :confused: 

Just for consistency and to be sure that this error will not happen again, I prefer to modify both scripts 