### PR TITLE
new approach for gdm restart in cob-start

### DIFF
--- a/PostInstallCob4.sh
+++ b/PostInstallCob4.sh
@@ -90,6 +90,7 @@ function  SetupRobotUser {
 
   echo -e "\n${green}INFO:Setup Robot User${NC}\n"
 
+  Entry
   /u/robot/git/setup_cob4/cob-adduser robot
 
   source /opt/ros/indigo/setup.bash #FIXME only working for indigo!!!
@@ -111,7 +112,7 @@ function  SetupRobotUser {
   fi
 
   for i in $pc_list; do
-    sudo -u root -i ssh-copy-id -i /u/robot/.ssh/id_rsa.pub robot@$i
+    sudo -u root -i ssh-copy-id robot@$i
     sudo -u root -i ssh robot@$i 'exit'
   done
   echo "setup robot user done"

--- a/PostInstallCob4.sh
+++ b/PostInstallCob4.sh
@@ -138,8 +138,9 @@ function SetupMimicUser {
   /u/robot/git/setup_cob4/cob-adduser mimic
 
   GDM_PATH=/etc/gdm/custom.conf
-  sudo ssh $pc_head "sed -i s/'#  AutomaticLoginEnable = true'/'AutomaticLoginEnable = true'/g $GDM_PATH"
-  sudo ssh $pc_head "sed -i s/'#  AutomaticLogin = user1'/'AutomaticLogin = mimic'/g $GDM_PATH"
+  sudo ssh $pc_head "sed -i s/'#  TimedLoginEnable = true'/'TimedLoginEnable = true'/g $GDM_PATH"
+  sudo ssh $pc_head "sed -i s/'#  TimedLogin = user1'/'TimedLogin = mimic'/g $GDM_PATH"
+  sudo ssh $pc_head "sed -i s/'#  TimedLoginDelay = 10'/'TimedLoginDelay = 10'/g $GDM_PATH"
 
   DESKTOP_PATH=/u/mimic/.config/autostart
   if sudo test -d $DESKTOP_PATH; then

--- a/PostInstallCob4.sh
+++ b/PostInstallCob4.sh
@@ -109,6 +109,11 @@ function  SetupRobotUser {
     cd /u/robot/git/care-o-bot/ && catkin config -DCMAKE_BUILD_TYPE=Release
     cd /u/robot/git/care-o-bot/ && catkin build
   fi
+
+  for i in $pc_list; do
+    sudo -u root -i ssh-copy-id -i /u/robot/.ssh/id_rsa.pub robot@$i
+    sudo -u root -i ssh robot@$i 'exit'
+  done
   echo "setup robot user done"
 }
 

--- a/images_config/ks-robot-master.cfg
+++ b/images_config/ks-robot-master.cfg
@@ -301,9 +301,13 @@ apt-get purge modemmanager -y
 %end
 
 ################ DISABLE POPUP FOR LTS UPDATES ################
-# 
 %post --erroronfail --interpreter /bin/bash
 sed -i 's/Prompt\=lts/Prompt\=never/g' /etc/update-manager/release-upgrades
+%end
+
+################ DISABLE FAILSAFE BOOT ################
+%post --erroronfail --interpreter /bin/bash
+sed -i 's/start on \(filesystem and static-network-up\) or failsafe-boot/start on filesystem and static-network-up/g' /etc/init/rc-sysinit.conf
 %end
 
 ################ INSTALL APT-CACHER ################ 

--- a/images_config/ks-robot-slave.cfg
+++ b/images_config/ks-robot-slave.cfg
@@ -320,9 +320,13 @@ apt-get purge modemmanager -y
 %end
 
 ################ DISABLE POPUP FOR LTS UPDATES ################
-# 
 %post --erroronfail --interpreter /bin/bash
 sed -i 's/Prompt\=lts/Prompt\=never/g' /etc/update-manager/release-upgrades
+%end
+
+################ DISABLE FAILSAFE BOOT ################
+%post --erroronfail --interpreter /bin/bash
+sed -i 's/start on \(filesystem and static-network-up\) or failsafe-boot/start on filesystem and static-network-up/g' /etc/init/rc-sysinit.conf
 %end
 
 ################ INSTALL APT-CACHER ################ 

--- a/upstart/cob-start
+++ b/upstart/cob-start
@@ -2,9 +2,7 @@
 
 set -e
 ROBOT=myrobot
-
 pcs="pc_list"
-
 camera_client_list="checkPc_list"
 
 for i in $pcs; do 
@@ -13,9 +11,6 @@ for i in $pcs; do
     done
     echo $i alive
 done
-
-# fixes https://github.com/ipa320/msh/issues/887 to not hang on login screen but boot into desktop
-ssh $ROBOT-h1 sudo service gdm restart
 
 for i in $camera_client_list; do 
     Check_cam=false
@@ -33,6 +28,42 @@ for i in $camera_client_list; do
       sleep 1
     done
 done
+
+# fixes https://github.com/ipa320/msh/issues/887 to not hang on login screen but boot into desktop
+while [ true ]
+  do
+    if [[ -n $( ssh $ROBOT-h1 'ps -ef | grep "gdm$"' ) ]]
+    then
+      echo "running"
+      break
+    fi
+  sleep 1
+done
+echo "stopping"
+ssh $ROBOT-h1 'sudo service gdm stop'
+while [ true ]
+  do
+    if [[ -z $( ssh $ROBOT-h1 'ps -ef | grep "gdm$"' ) ]]
+    then
+      echo "stopped"
+      break
+    fi
+  sleep 1
+done
+echo "restarting"
+ssh $ROBOT-h1 'sudo service gdm restart'
+while [ true ]
+  do
+    if [[ -n $( ssh $ROBOT-h1 'ps -ef | grep "gdm$"' ) ]]
+    then
+      echo "running"
+      break
+    fi
+  sleep 1
+done
+sleep 10 # wait until screen is rotated
+echo "slept"
+
 
 function log() {
   logger -s -p user.$1 ${@:2}

--- a/upstart/cob-start
+++ b/upstart/cob-start
@@ -5,68 +5,48 @@ ROBOT=myrobot
 pcs="pc_list"
 camera_client_list="checkPc_list"
 
-for i in $pcs; do 
-    until ping -c1 $i &>/dev/null; do
-        echo $i not found
+for i in $pcs; do
+    while [ true ]
+      do
+        if ping -c1 $i &>/dev/null
+          then
+            echo "$i: ping ok"
+            if ssh robot@$i '[ -d /u ]';
+              then
+                echo "$i: nfs set up"
+                break
+            else
+                echo "$i: nfs not ready"
+            fi
+        else
+            echo "$i: ping failed"
+        fi
+        sleep 1
     done
-    echo $i alive
 done
 
-for i in $camera_client_list; do 
-    Check_cam=false
-    while [[ !$Check_cam ]]
+for i in $camera_client_list; do
+    while [ true ]
       do
         echo $(date)
         if ssh $i stat /tmp/check_done \> /dev/null 2\>\&1
           then
-            echo "$i File exists"
-            Check_cam=true
+            echo "$i: cam_check done"
             break
           else
-            echo "$i File still does not exist"
+            echo "$i: cam_check pending"
         fi
       sleep 1
     done
 done
 
-# fixes https://github.com/ipa320/msh/issues/887 to not hang on login screen but boot into desktop
-while [ true ]
-  do
-    if [[ -n $( ssh $ROBOT-h1 'ps -ef | grep "gdm$"' ) ]]
-    then
-      echo "running"
-      break
-    fi
-  sleep 1
-done
-echo "stopping"
-ssh $ROBOT-h1 'sudo service gdm stop'
-while [ true ]
-  do
-    if [[ -z $( ssh $ROBOT-h1 'ps -ef | grep "gdm$"' ) ]]
-    then
-      echo "stopped"
-      break
-    fi
-  sleep 1
-done
-echo "restarting"
-ssh $ROBOT-h1 'sudo service gdm restart'
-while [ true ]
-  do
-    if [[ -n $( ssh $ROBOT-h1 'ps -ef | grep "gdm$"' ) ]]
-    then
-      echo "running"
-      break
-    fi
-  sleep 1
-done
-sleep 10 # wait until screen is rotated
-echo "slept"
-
+# wait until screen is rotated
+echo "waiting for screen to rotate"
+sleep 10
 
 function log() {
   logger -s -p user.$1 ${@:2}
 }
 
+echo "cob-command start"
 /usr/sbin/cob-command start

--- a/upstart/cob-start
+++ b/upstart/cob-start
@@ -40,13 +40,19 @@ for i in $camera_client_list; do
     done
 done
 
+# wait for mimic to be logged in into -h1
+while [ true ]; do
+  echo "waiting for mimic to be logged in into -h1"
+  if [[ -n $( ssh $ROBOT-h1 'who |grep ":0"| grep mimic') ]]; then
+    echo "mimic logged in into -h1"
+    break
+  fi
+  sleep 1
+done
+
 # wait until screen is rotated
 echo "waiting for screen to rotate"
 sleep 10
-
-function log() {
-  logger -s -p user.$1 ${@:2}
-}
 
 echo "cob-command start"
 /usr/sbin/cob-command start


### PR DESCRIPTION
fixes https://github.com/ipa320/msh/issues/887

I don't know what the problem is:
If I update `cob-start` to this version - using `PostInstallScript`, manually typing `sudo cob-start` does exactly what it is supposed to do, i.e. stop gdm (=terminal mode), restart gdm (bring back screen and rotate) and then start bringup...eventually mimic (vlc) is started
However, if this script is used during boot procedure, it does stop gdm (=terminal mode on head screen), but does not bring back `gdm` although `sudo service gdm status` says running

@ipa-bnm @ipa-fmw @ipa-nhg any ideas?
@HannesBachter FYI

If we solve this inconsistency between manuall `sudo cob-start` and "`cob-start` during boot", it might be that @HannesBachter's solution from #183 already was sufficient! 