### PR TITLE
allow passthrough for apt-cacher

### DIFF
--- a/images_config/ks-robot-master.cfg
+++ b/images_config/ks-robot-master.cfg
@@ -307,5 +307,5 @@ echo 'Acquire::http { Proxy "http://server_ip:3142"; };' >> /etc/apt/apt.conf.d/
 HOSTNAME=$(cat /etc/hostname)
 SERVERNAME=$(echo ${HOSTNAME%-*}-b1)
 sed -i "s/server_ip/${SERVERNAME}/g" /etc/apt/apt.conf.d/01proxy
+sed -i 's/\# PassThroughPattern: .\*/PassThroughPattern: .\*/g' /etc/apt-cacher-ng/acng.conf
 %end
-


### PR DESCRIPTION
needed for `git-lfs` (see https://github.com/ipa320/setup_cob4/issues/170)