### PR TITLE
add step to install git-lfs

### DIFF
--- a/images_config/ks-robot-master.cfg
+++ b/images_config/ks-robot-master.cfg
@@ -194,6 +194,13 @@ apt-get install python-wstool -y
 apt-get install python-pip -y
 %end
 
+################ INSTALLING GIT-LFS ################ 
+%post --erroronfail --interpreter /bin/bash
+curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+apt-get update
+apt-get install git-lfs
+%end
+
 ################ SETUP DEFAULT BASH ENVIROMENT ################ 
 %post --erroronfail --interpreter /bin/bash
 wget -O /etc/cob.bash.bashrc https://raw.githubusercontent.com/ipa320/setup_cob4/master/cob-pcs/cob.bash.bashrc.b

--- a/images_config/ks-robot-slave.cfg
+++ b/images_config/ks-robot-slave.cfg
@@ -195,6 +195,13 @@ apt-get install python-wstool -y
 apt-get install python-pip -y
 %end
 
+################ INSTALLING GIT-LFS ################ 
+%post --erroronfail --interpreter /bin/bash
+curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+apt-get update
+apt-get install git-lfs
+%end
+
 ################ SETUP DEFAULT BASH ENVIROMENT ################ 
 %post --erroronfail --interpreter /bin/bash
 ROBOT=$(echo ${HOSTNAME%-*})


### PR DESCRIPTION
added install step for `git-lfs` (see https://github.com/ipa320/setup_cob4/issues/170)

during image_setup, cob-kitchen-server is apt-cacher!
@ipa-fmw enabled passthrough for this

#188 is only needed for updating `git-lfs` on the robots