### PR TITLE
Bug tutorial and txt cfg

### DIFF
--- a/images_config/README.md
+++ b/images_config/README.md
@@ -86,7 +86,7 @@ cp -r ~/ubuntu_iso ~/ubuntu_files
 chmod +w -R ~/ubuntu_files
 echo en >> ~/ubuntu_files/isolinux/lang
 cp -r ~/git/setup_cob4/images_config/kickstart ~/ubuntu_files/
-cp ~/git/setup_cob4/images_config/preseed ~/ubuntu_files/
+cp -r ~/git/setup_cob4/images_config/preseed ~/ubuntu_files/
 cp ~/git/setup_cob4/images_config/isolinux/txt-14.04.cfg ~/ubuntu_files/isolinux/txt.cfg
 cp ~/git/setup_cob4/images_config/initrd.gz ~/ubuntu_files/install/
 mkisofs -D -r -V "Ubuntu-14.04-Care-O-bot" -cache-inodes -J -l -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -o ~/ubuntu-14.04-care-o-bot.iso ~/ubuntu_files
@@ -105,7 +105,7 @@ cp -r ~/ubuntu_iso ~/ubuntu_files
 chmod +w -R ~/ubuntu_files
 echo en >> ~/ubuntu_files/isolinux/lang
 cp -r ~/git/setup_cob4/images_config/kickstart ~/ubuntu_files/
-cp ~/git/setup_cob4/images_config/preseed ~/ubuntu_files/
+cp -r ~/git/setup_cob4/images_config/preseed ~/ubuntu_files/
 cp ~/git/setup_cob4/images_config/isolinux/txt-16.04.cfg ~/ubuntu_files/isolinux/txt.cfg
 mkisofs -D -r -V "Ubuntu-16.04-Care-O-bot" -cache-inodes -J -l -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -o ~/ubuntu-16.04-care-o-bot.iso ~/ubuntu_files
 ```

--- a/images_config/isolinux/txt-14.04.cfg
+++ b/images_config/isolinux/txt-14.04.cfg
@@ -1,19 +1,19 @@
 label cob-master
   menu label ^Care-O-bot Master
   kernel /install/vmlinuz
-  append file=/cdrom/preseed/ubuntu-server.seed vga=788 initrd=/install/initrd.gz ks=cdrom:/ks-14.04-robot-master.cfg preseed/file=/cdrom/ubuntu-14.04-auto.seed quiet --
+  append file=/cdrom/preseed/ubuntu-server.seed vga=788 initrd=/install/initrd.gz ks=cdrom:/kickstart/ks-14.04-robot-master.cfg preseed/file=/cdrom/preseed/ubuntu-14.04-auto.seed quiet --
 
 label cob-master-cached
   menu label ^Care-O-bot Master apt cached
   kernel /install/vmlinuz
-  append file=/cdrom/preseed/ubuntu-server.seed vga=788 initrd=/install/initrd.gz ks=cdrom:/ks-14.04-robot-master.cfg preseed/file=/cdrom/ubuntu-14.04-auto-cached.seed quiet --
+  append file=/cdrom/preseed/ubuntu-server.seed vga=788 initrd=/install/initrd.gz ks=cdrom:/kickstart/ks-14.04-robot-master.cfg preseed/file=/cdrom/preseed/ubuntu-14.04-auto-cached.seed quiet --
 
 label cob-slave
   menu label ^Care-O-bot Slave
   kernel /install/vmlinuz
-  append file=/cdrom/preseed/ubuntu-server.seed vga=788 initrd=/install/initrd.gz ks=cdrom:/ks-14.04-robot-slave.cfg preseed/file=/cdrom/ubuntu-14.04-auto.seed quiet --
+  append file=/cdrom/preseed/ubuntu-server.seed vga=788 initrd=/install/initrd.gz ks=cdrom:/kickstart/ks-14.04-robot-slave.cfg preseed/file=/cdrom/preseed/ubuntu-14.04-auto.seed quiet --
 
 label cob-slave-cached
   menu label ^Care-O-bot Slave apt cached
   kernel /install/vmlinuz
-  append file=/cdrom/preseed/ubuntu-server.seed vga=788 initrd=/install/initrd.gz ks=cdrom:/ks-14.04-robot-slave.cfg preseed/file=/cdrom/ubuntu-14.04-auto-cached.seed quiet --
+  append file=/cdrom/preseed/ubuntu-server.seed vga=788 initrd=/install/initrd.gz ks=cdrom:/kickstart/ks-14.04-robot-slave.cfg preseed/file=/cdrom/preseed/ubuntu-14.04-auto-cached.seed quiet --


### PR DESCRIPTION
Hi, 

While installing a COB PC, we encountered two problems in the repo. 

1. There should be "-r" in the 89th and 108th line of images_config/README.md. Otherwise, we are getting omitting directory error from cp command. 
2. In txt-14.04.cfg file, /kickstart/ and /preseed/ should be added to the paths. Otherwise, it could not find the config ks and seed files and continue with the normal installation.

Best, 
Cagatay 