### PR TITLE
Non-Interactive FSCKFIX

### DIFF
--- a/images_config/kickstart/kickstart-robot.sh
+++ b/images_config/kickstart/kickstart-robot.sh
@@ -369,6 +369,15 @@ function DisableFailsafeBoot {
     fi
 }
 
+function NonInteractiveFSCKFIX {
+    printHeader "NonInteractiveFSCKFIX"
+    if [ "$DISTRO" == "trusty" ]; then
+        sed -i '/FSCKFIX\=no/c\FSCKFIX\=yes' /etc/default/rcS
+    elif [ "$DISTRO" == "xenial" ]; then
+        sed -i '/FSCKFIX\=no/c\FSCKFIX\=yes' /lib/init/vars.sh
+    fi
+}
+
 function InstallAptCacher {
     printHeader "InstallAptCacher"
     #disable local forward to 10.0.1.1 cacher
@@ -479,6 +488,7 @@ InstallCobCommand
 RemoveModemanager
 DisableUpdatePopup
 DisableFailsafeBoot
+NonInteractiveFSCKFIX
 InstallRealsense
 InstallCareOBot
 InstallAptCacher

--- a/images_config/kickstart/kickstart-robot.sh
+++ b/images_config/kickstart/kickstart-robot.sh
@@ -360,11 +360,13 @@ function DisableUpdatePopup {
     sed -i 's/Prompt\=lts/Prompt\=never/g' /etc/update-manager/release-upgrades
 }
 
-# Observe if we still need it under xenial
-# Not functional under xenial
 function DisableFailsafeBoot {
     printHeader "DisableFailsafeBoot"
-    sed -i 's/start on \(filesystem and static-network-up\) or failsafe-boot/start on filesystem and static-network-up/g' /etc/init/rc-sysinit.conf
+    if [ "$DISTRO" == "trusty" ]; then
+        sed -i 's/start on \(filesystem and static-network-up\) or failsafe-boot/start on filesystem and static-network-up/g' /etc/init/rc-sysinit.conf
+    elif [ "$DISTRO" == "xenial" ]; then
+        : #ToDo: not functional under xenial
+    fi
 }
 
 function InstallAptCacher {
@@ -476,7 +478,7 @@ InstallNetData
 InstallCobCommand
 RemoveModemanager
 DisableUpdatePopup
-#DisableFailsafeBoot
+DisableFailsafeBoot
 InstallRealsense
 InstallCareOBot
 InstallAptCacher


### PR DESCRIPTION
handles #211 - not tested yet (as it is hard to reproduce the fsck situation...)

but it still does not fix the main cause why the pcs **requires** fsckfix to run in the first place
one possible reason is that those pcs do not should down properly - or simply take longer (because a process is still being stopped) than the 60secs timeout in [`cob_shutdown`](https://github.com/ipa320/setup_cob4/blob/master/scripts/cob-shutdown#L38)